### PR TITLE
Add canonically-cased config options

### DIFF
--- a/config.go
+++ b/config.go
@@ -585,6 +585,11 @@ func NewKV(key, value string) *KV {
 	}
 }
 
+// CanonicalKey returns k's Key, using the canonical casing from https://man.openbsd.org/ssh_config.
+func (k *KV) CanonicalKey() string {
+	return GetCanonicalCase(k.Key)
+}
+
 // Pos returns k's Position.
 func (k *KV) Pos() Position {
 	return k.position
@@ -600,7 +605,7 @@ func (k *KV) String() string {
 	if k.hasEquals {
 		equals = " = "
 	}
-	line := fmt.Sprintf("%s%s%s%s", strings.Repeat(" ", int(k.leadingSpace)), k.Key, equals, k.Value)
+	line := fmt.Sprintf("%s%s%s%s", strings.Repeat(" ", k.leadingSpace), k.CanonicalKey(), equals, k.Value)
 	if k.Comment != "" {
 		line += " #" + k.Comment
 	}

--- a/config_options.go
+++ b/config_options.go
@@ -1,0 +1,143 @@
+package ssh_config
+
+import (
+	"strings"
+)
+
+// Current as of OpenSSH 8.2
+// Source: https://man.openbsd.org/ssh_config
+var configOptions = []string{
+	"Host",
+	"Match",
+	"AddKeysToAgent",
+	"AddressFamily",
+	"BatchMode",
+	"BindAddress",
+	"BindInterface",
+	"CanonicalDomains",
+	"CanonicalizeFallbackLocal",
+	"CanonicalizeHostname",
+	"CanonicalizeMaxDots",
+	"CanonicalizePermittedCNAMEs",
+	"CASignatureAlgorithms",
+	"CertificateFile",
+	"CheckHostIP",
+	"Ciphers",
+	"ClearAllForwardings",
+	"Compression",
+	"ConnectionAttempts",
+	"ConnectTimeout",
+	"ControlMaster",
+	"ControlPath",
+	"ControlPersist",
+	"DynamicForward",
+	"EnableSSHKeysign",
+	"EscapeChar",
+	"ExitOnForwardFailure",
+	"FingerprintHash",
+	"ForkAfterAuthentication",
+	"ForwardAgent",
+	"ForwardX11",
+	"ForwardX11Timeout",
+	"ForwardX11Trusted",
+	"GatewayPorts",
+	"GlobalKnownHostsFile",
+	"GSSAPIAuthentication",
+	"GSSAPIDelegateCredentials",
+	"HashKnownHosts",
+	"HostbasedAcceptedAlgorithms",
+	"HostbasedAuthentication",
+	"HostKeyAlgorithms",
+	"HostKeyAlias",
+	"Hostname",
+	"IdentitiesOnly",
+	"IdentityAgent",
+	"IdentityFile",
+	"IgnoreUnknown",
+	"Include",
+	"IPQoS",
+	"KbdInteractiveAuthentication",
+	"KbdInteractiveDevices",
+	"KexAlgorithms",
+	"KnownHostsCommand",
+	"LocalCommand",
+	"LocalForward",
+	"LogLevel",
+	"LogVerbose",
+	"MACs",
+	"NoHostAuthenticationForLocalhost",
+	"NumberOfPasswordPrompts",
+	"PasswordAuthentication",
+	"PermitLocalCommand",
+	"PermitRemoteOpen",
+	"PKCS11Provider",
+	"Port",
+	"PreferredAuthentications",
+	"ProxyCommand",
+	"ProxyJump",
+	"ProxyUseFdpass",
+	"PubkeyAcceptedAlgorithms",
+	"PubkeyAuthentication",
+	"RekeyLimit",
+	"RemoteCommand",
+	"RemoteForward",
+	"RequestTTY",
+	"RevokedHostKeys",
+	"SecurityKeyProvider",
+	"SendEnv",
+	"ServerAliveCountMax",
+	"ServerAliveInterval",
+	"SessionType",
+	"SetEnv",
+	"StdinNull",
+	"StreamLocalBindMask",
+	"StreamLocalBindUnlink",
+	"StrictHostKeyChecking",
+	"SyslogFacility",
+	"TCPKeepAlive",
+	"Tunnel",
+	"TunnelDevice",
+	"UpdateHostKeys",
+	"User",
+	"UserKnownHostsFile",
+	"VerifyHostKeyDNS",
+	"VisualHostKey",
+	"XAuthLocation",
+}
+
+// // getConfigOptions retrieves a sorted list of all the current config options
+// // from the official source: https://man.openbsd.org/ssh_config and filtered
+// // with "github.com/PuerkitoBio/goquery".
+// // The result is sorted and therefore may be searched with sort.SearchStrings()
+// func getConfigOptions() (opts []string, err error) {
+// 	SSHConfigURL := "https://man.openbsd.org/ssh_config"
+
+// 	resp, err := http.Get(SSHConfigURL)
+// 	if err != nil {
+// 		return opts, fmt.Errorf("getting %s: %w", SSHConfigURL, err)
+// 	}
+// 	defer resp.Body.Close()
+
+// 	doc, err := goquery.NewDocumentFromReader(resp.Body)
+// 	if err != nil {
+// 		return opts, fmt.Errorf("parsing %s: %w", SSHConfigURL, err)
+// 	}
+
+// 	doc.Find("dt > a > code.Cm").Each(func(i int, c *goquery.Selection) {
+// 		opts = append(opts, c.Text())
+// 	})
+
+// 	sort.Strings(opts)
+// 	return opts, nil
+// }
+
+// GetCanonicalCase checks for the given key in the known ssh config keys
+// and returns with proper casing if found, otherwise returns what was given.
+func GetCanonicalCase(key string) string {
+	for _, value := range configOptions {
+		if strings.EqualFold(key, value) {
+			return value
+		}
+	}
+	return key
+}


### PR DESCRIPTION
This PR adds a list of config options pulled from https://man.openbsd.org/ssh_config (an example function to re-pull the list is included as well, commented out), and adds a `KV.CanonicalKey()` function, such that when printed with String(), the proper case is used for the Key, rather than all lowercase.

Example:
```
Host ssh.github.com gist.github.com github.com github
    Hostname ssh.github.com
    IdentitiesOnly yes
    IdentityFile ~/.ssh/id_ed25519
    User git
```
Without this, when [manssh](https://github.com/xwjdsh/manssh) prints:
```
        gist.github.com -> git@ssh.github.com:22
            identitiesonly = yes
            identityfile = ~/.ssh/id_ed25519

        github -> git@ssh.github.com:22
            identitiesonly = yes
            identityfile = ~/.ssh/id_ed25519

        github.com -> git@ssh.github.com:22
            identitiesonly = yes
            identityfile = ~/.ssh/id_ed25519

        github.me -> git@ssh.github.com:22
            identitiesonly = yes
            identityfile = ~/.ssh/id_ed25519

        ssh.github.com -> git@ssh.github.com:22
            identitiesonly = yes
            identityfile = ~/.ssh/id_ed25519
```

the ~/.ssh/config file is also modified:
```
Host ssh.github.com gist.github.com github.com github
    hostname ssh.github.com
    identitiesonly yes
    identityfile ~/.ssh/id_ed25519
    user git
```

With this change, the case is preserved in the file, though printing still lowercases the keys.

NOTE: An identical PR has also been made upstream: https://github.com/kevinburke/ssh_config/pull/39 so this can be closed if that one is merged in first.